### PR TITLE
Error en la fórmula

### DIFF
--- a/Python/clases/3_algebra_lineal/3_minimos_cuadrados.ipynb
+++ b/Python/clases/3_algebra_lineal/3_minimos_cuadrados.ipynb
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$$R^TR\\beta = R^Ty$$"
+    "$$R^TR\\beta = R^TQ^Ty$$"
    ]
   },
   {


### PR DESCRIPTION
Se omite la Q^T una vez aplicada la Ortonormalidad de Q.